### PR TITLE
Fix board loading by using JSON data

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,6 @@
     <aside class="sidebar">
       <div class="card progress-card">
         <div>
-          <span id="theme"></span>
           <div class="theme-label">Theme</div>
           <div id="theme" class="theme-value">—</div>
         </div>
@@ -121,9 +120,6 @@
       </div>
     </div>
   </div>
-
-  <!-- Data first -->
-  <script src="js/board/boards.js"></script>
 
   <!-- App entry (ES modules import the rest) -->
   <script type="module" src="js/main.js"></script>

--- a/js/board/board.js
+++ b/js/board/board.js
@@ -10,8 +10,14 @@ export async function loadBoards() {
     state.boards = window.BOARDS;
     return;
   }
-  const res = await fetch('boards.json');
-  state.boards = await res.json();
+
+  try {
+    const data = await import('./boards.json', { assert: { type: 'json' } });
+    state.boards = data.default;
+  } catch {
+    const res = await fetch(new URL('./boards.json', import.meta.url));
+    state.boards = await res.json();
+  }
 }
 
 export function setupBoard(restartSame = false) {

--- a/js/board/boards.json
+++ b/js/board/boards.json
@@ -1,29 +1,28 @@
-// js/board/boards.js
-window.BOARDS = [
+[
   {
-    theme: "Treasure & Tools",
-    cols: 7,
-    rows: 5,
-    grid: [
+    "theme": "Treasure & Tools",
+    "cols": 7,
+    "rows": 5,
+    "grid": [
       "G","O","L","E","S","M","H",
       "K","D","N","O","T","A","M",
       "Y","E","L","E","R","R","E",
       "K","O","O","C","W","N","I",
       "C","W","O","D","S","A","L"
     ],
-    words: ["GOLD","STONE","KEY","LOCK","WOOD","SAW","SCREW","HAMMER","NAIL"]
+    "words": ["GOLD","STONE","KEY","LOCK","WOOD","SAW","SCREW","HAMMER","NAIL"]
   },
   {
-    theme: "Materials",
-    cols: 7,
-    rows: 5,
-    grid: [
+    "theme": "Materials",
+    "cols": 7,
+    "rows": 5,
+    "grid": [
       "I","R","O","E","S","M","T",
       "K","N","N","O","T","I","R",
       "Y","E","L","E","R","N","O",
       "K","O","O","C","W","D","S",
       "C","W","O","D","S","E","L"
     ],
-    words: ["IRON","STONE","KEY","LOCK","WOOD","SAW","SCREW"]
+    "words": ["IRON","STONE","KEY","LOCK","WOOD","SAW","SCREW"]
   }
-];
+]

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,3 @@
-import './board/boards.js';
-
 import { loadBoards, setupBoard, endSelect } from './board/board.js';
 import { sizeLocksRow } from './locks/locks.js';
 import { setupDragAndDrop } from './inventory/inventory.js';


### PR DESCRIPTION
## Summary
- Load board layouts by dynamically importing `boards.json` with a fetch fallback so the grid initializes even without a server
- Remove duplicate theme element in `index.html` so the current board theme displays correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a2f2c1e588330abb9fcc6f79f1825